### PR TITLE
Api gateway service retry wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.iml
+*.orig
+*.zip
 .idea/**/*
 coverage/**/*
 node_modules/**/*

--- a/lib/service/ApiBasePathMapping/ApiBasePathMappingService.js
+++ b/lib/service/ApiBasePathMapping/ApiBasePathMappingService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var getWrappedService = require('../util/api-gateway-retry-wrapper');
 var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var logger = require('../util/logger');
 

--- a/lib/service/ApiBasePathMapping/ApiBasePathMappingService.js
+++ b/lib/service/ApiBasePathMapping/ApiBasePathMappingService.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var ApiGatewayRetryWrapper = require('./util/api-gateway-retry-wrapper');
-var awsApiGateway = new ApiGatewayRetryWrapper({ apiVersion: '2015-07-09' });
+var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var logger = require('../util/logger');
 
 var pub = {};

--- a/lib/service/ApiBasePathMapping/ApiBasePathMappingService.js
+++ b/lib/service/ApiBasePathMapping/ApiBasePathMappingService.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var aws = require('aws-sdk');
-var awsApiGateway = new aws.APIGateway({ apiVersion: '2015-07-09' });
+var ApiGatewayRetryWrapper = require('./util/api-gateway-retry-wrapper');
+var awsApiGateway = new ApiGatewayRetryWrapper({ apiVersion: '2015-07-09' });
 var logger = require('../util/logger');
 
 var pub = {};

--- a/lib/service/ApiDomainName/ApiDomainNameService.js
+++ b/lib/service/ApiDomainName/ApiDomainNameService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var getWrappedService = require('../util/api-gateway-retry-wrapper');
 var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var logger = require('../util/logger');
 

--- a/lib/service/ApiDomainName/ApiDomainNameService.js
+++ b/lib/service/ApiDomainName/ApiDomainNameService.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var aws = require('aws-sdk');
-var awsApiGateway = new aws.APIGateway({ apiVersion: '2015-07-09' });
+var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var logger = require('../util/logger');
 
 var pub = {};

--- a/lib/service/ApiMethod/ApiMethodService.js
+++ b/lib/service/ApiMethod/ApiMethodService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var getWrappedService = require('../util/api-gateway-retry-wrapper');
 var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var async = require('async');
 var ApiMethodEvent = require('./ApiMethodEvent');

--- a/lib/service/ApiMethod/ApiMethodService.js
+++ b/lib/service/ApiMethod/ApiMethodService.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var aws = require('aws-sdk');
-var awsApiGateway = new aws.APIGateway({ apiVersion: '2015-07-09' });
+var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var async = require('async');
 var ApiMethodEvent = require('./ApiMethodEvent');
 var Constants = require('../Constants');

--- a/lib/service/ApiModel/ApiModelService.js
+++ b/lib/service/ApiModel/ApiModelService.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var aws = require('aws-sdk');
-var awsApiGateway = new aws.APIGateway({ apiVersion: '2015-07-09' });
+var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var ApiModelEvent = require('./ApiModelEvent');
 var logger = require('../util/logger');
 

--- a/lib/service/ApiModel/ApiModelService.js
+++ b/lib/service/ApiModel/ApiModelService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var getWrappedService = require('../util/api-gateway-retry-wrapper');
 var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var ApiModelEvent = require('./ApiModelEvent');
 var logger = require('../util/logger');

--- a/lib/service/ApiResource/ApiResourceService.js
+++ b/lib/service/ApiResource/ApiResourceService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var getWrappedService = require('../util/api-gateway-retry-wrapper');
 var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var ApiResourceEvent = require('./ApiResourceEvent');
 var Constants = require('../Constants');

--- a/lib/service/ApiResource/ApiResourceService.js
+++ b/lib/service/ApiResource/ApiResourceService.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var aws = require('aws-sdk');
-var awsApiGateway = new aws.APIGateway({ apiVersion: '2015-07-09' });
+var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var ApiResourceEvent = require('./ApiResourceEvent');
 var Constants = require('../Constants');
 var CorsService = require('../Cors/CorsService');

--- a/lib/service/Cors/CorsService.js
+++ b/lib/service/Cors/CorsService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var getWrappedService = require('../util/api-gateway-retry-wrapper');
 var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var async = require('async');
 var ApiMethodService = require('../ApiMethod/ApiMethodService');

--- a/lib/service/Cors/CorsService.js
+++ b/lib/service/Cors/CorsService.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var aws = require('aws-sdk');
-var awsApiGateway = new aws.APIGateway({ apiVersion: '2015-07-09' });
+var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var async = require('async');
 var ApiMethodService = require('../ApiMethod/ApiMethodService');
 var Constants = require('../Constants');

--- a/lib/service/Cors/GetCorsMethodUpdateOperations.js
+++ b/lib/service/Cors/GetCorsMethodUpdateOperations.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var aws = require('aws-sdk');
-var awsApiGateway = new aws.APIGateway({ apiVersion: '2015-07-09' });
+var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var Constants = require('./../Constants');
 var _ = require('lodash');
 var async = require('async');

--- a/lib/service/Cors/GetCorsMethodUpdateOperations.js
+++ b/lib/service/Cors/GetCorsMethodUpdateOperations.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var getWrappedService = require('../util/api-gateway-retry-wrapper');
 var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var Constants = require('./../Constants');
 var _ = require('lodash');

--- a/lib/service/RestApi/RestApiService.js
+++ b/lib/service/RestApi/RestApiService.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var getWrappedService = require('../util/api-gateway-retry-wrapper');
 var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var ApiResourceService = require('../ApiResource/ApiResourceService');
 var RestApiEvent = require('./RestApiEvent');

--- a/lib/service/RestApi/RestApiService.js
+++ b/lib/service/RestApi/RestApiService.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var aws = require('aws-sdk');
-var awsApiGateway = new aws.APIGateway({ apiVersion: '2015-07-09' });
+var getWrappedService = require('./util/api-gateway-retry-wrapper');
+var awsApiGateway = getWrappedService({ apiVersion: '2015-07-09' });
 var ApiResourceService = require('../ApiResource/ApiResourceService');
 var RestApiEvent = require('./RestApiEvent');
 var Constants = require('../Constants');

--- a/lib/service/util/api-gateway-retry-wrapper.js
+++ b/lib/service/util/api-gateway-retry-wrapper.js
@@ -1,0 +1,90 @@
+'use strict';
+
+var aws = require('aws-sdk');
+var _retryIntervalMs;
+var _maxRetries;
+
+var GetWrappedService = function (options, retryIntervalMs, maxRetries) {
+	_retryIntervalMs = retryIntervalMs || (15 * 1000);
+	_maxRetries = maxRetries || 8;
+
+	var apiGateway = new aws.APIGateway(options);
+	_wrapMethods(apiGateway);
+
+	return apiGateway;
+};
+
+function _wrapMethods(apiGateway) {
+	for (var prop in apiGateway)
+	{
+		var value = apiGateway[prop];
+
+		if (_isWrappableMethod(value))
+		{
+			_wrapMethod(apiGateway, key, value);
+		}
+	}
+}
+
+function _isWrappableMethod (value) {
+	return typeof (value) === "function";
+}
+
+function _wrapMethod (apiGateway, methodName, method) {
+	apiGateway[methodName] = _getWrappedMethod(apiGateway, methodName, method);
+}
+
+function _getWrappedMethod (apiGateway, methodName, method) {
+	return function (params, callback) {
+		var invocationData = {
+			apiGateway: apiGateway,
+			methodName: methodName,
+			method: method,
+			retryCount: 0,
+			params: params,
+			originalCallback: callback
+		};
+
+		// Invoke original method repeatedly until no TooManyRequestsException or max retry limit hit.
+		_invokeInnerMethod(invocationData);
+	};
+}
+
+function _invokeInnerMethod (invocationData) {
+	// Replace the original callback with our own to check for TooManyRequests exceptions.
+	var retryCheck = function (err, data) {
+		if (err && _isRetryableError(err))
+		{
+			if (++invocationData.retryCount < _maxRetries)
+			{
+				// Wait then retry.
+				console.log(invocationData.methodName + " failed with TooManyRequestsException; retrying in " + _retryIntervalMs);
+				setTimeout(function () {
+					console.log("Retrying " + invocationData.methodName);
+					_invokeInnerMethod(invocationData);
+				}, _retryIntervalMs);
+
+				// Drop out so we don't invoke the original callback.
+				return;
+			}
+			else
+			{
+				// Too many retries - abandon ship.
+				console.log(invocationData.methodName + " failed with TooManyRequestsException and reached max retry count (" + _maxRetries + ")");
+			}
+		}
+
+		// If we reach here, the call either:
+		//  - succeeded (yay);
+		//  - failed with an error other than TooManyRequests;
+		//  - reached the max retry count after numerous TooManyRequests errors.
+		// Whichever, we still need to invoke the original callback.
+		invocationData.originalCallback(err, data);
+	};
+
+	method.call(invocationData.apiGateway, invocationData.params, retryCheck);
+}
+
+function _isRetryableError (err) {
+	return err && (err.code === "TooManyRequestsException");
+}

--- a/lib/service/util/api-gateway-retry-wrapper.js
+++ b/lib/service/util/api-gateway-retry-wrapper.js
@@ -1,90 +1,98 @@
 'use strict';
 
+var logger = require('./logger');
 var aws = require('aws-sdk');
-var _retryIntervalMs;
+var _minRetryIntervalMs;
 var _maxRetries;
 
-var GetWrappedService = function (options, retryIntervalMs, maxRetries) {
-	_retryIntervalMs = retryIntervalMs || (15 * 1000);
-	_maxRetries = maxRetries || 8;
+function GetWrappedService(options, minRetryIntervalMs, maxRetries) {
+    _minRetryIntervalMs = minRetryIntervalMs || 2000;
+    _maxRetries = maxRetries || 8;
 
-	var apiGateway = new aws.APIGateway(options);
-	_wrapMethods(apiGateway);
+    var apiGateway = new aws.APIGateway(options);
+    _wrapMethods(apiGateway);
 
-	return apiGateway;
-};
+    return apiGateway;
+}
 
 function _wrapMethods(apiGateway) {
-	for (var prop in apiGateway)
-	{
-		var value = apiGateway[prop];
+    for (var prop in apiGateway) {
+        if (!apiGateway.hasOwnProperty(prop)) {
+            continue;
+        }
 
-		if (_isWrappableMethod(value))
-		{
-			_wrapMethod(apiGateway, key, value);
-		}
-	}
+        var value = apiGateway[prop];
+
+        if (_isWrappableMethod(value)) {
+            _wrapMethod(apiGateway, prop, value);
+        }
+    }
 }
 
-function _isWrappableMethod (value) {
-	return typeof (value) === "function";
+function _isWrappableMethod(value) {
+    return typeof value === 'function';
 }
 
-function _wrapMethod (apiGateway, methodName, method) {
-	apiGateway[methodName] = _getWrappedMethod(apiGateway, methodName, method);
+function _wrapMethod(apiGateway, methodName, method) {
+    apiGateway[methodName] = _getWrappedMethod(apiGateway, methodName, method);
 }
 
-function _getWrappedMethod (apiGateway, methodName, method) {
-	return function (params, callback) {
-		var invocationData = {
-			apiGateway: apiGateway,
-			methodName: methodName,
-			method: method,
-			retryCount: 0,
-			params: params,
-			originalCallback: callback
-		};
+function _getWrappedMethod(apiGateway, methodName, method) {
+    return function (params, callback) {
+        var invocationData = {
+            apiGateway: apiGateway,
+            methodName: methodName,
+            method: method,
+            retryCount: 0,
+            params: params,
+            originalCallback: callback
+        };
 
-		// Invoke original method repeatedly until no TooManyRequestsException or max retry limit hit.
-		_invokeInnerMethod(invocationData);
-	};
+        // Invoke original method repeatedly until no TooManyRequestsException or max retry limit hit.
+        _invokeInnerMethod(invocationData);
+    };
 }
 
-function _invokeInnerMethod (invocationData) {
-	// Replace the original callback with our own to check for TooManyRequests exceptions.
-	var retryCheck = function (err, data) {
-		if (err && _isRetryableError(err))
-		{
-			if (++invocationData.retryCount < _maxRetries)
-			{
-				// Wait then retry.
-				console.log(invocationData.methodName + " failed with TooManyRequestsException; retrying in " + _retryIntervalMs);
-				setTimeout(function () {
-					console.log("Retrying " + invocationData.methodName);
-					_invokeInnerMethod(invocationData);
-				}, _retryIntervalMs);
+function _invokeInnerMethod(invocationData) {
+    // Replace the original callback with our own to check for TooManyRequests exceptions.
+    var retryCheck = function (err, data) { //eslint-disable-line func-style
+        if (err && _isRetryableError(err)) {
+            if (++invocationData.retryCount < _maxRetries) {
+                // Wait then retry.
+                var retryIntervalMs = _getRetryInterval();
+                logger.log(invocationData.methodName + ' failed with TooManyRequestsException; retrying in ' + retryIntervalMs); setTimeout(function () {
+                    logger.log('Retrying ' + invocationData.methodName);
+                    _invokeInnerMethod(invocationData);
+                }, retryIntervalMs);
 
-				// Drop out so we don't invoke the original callback.
-				return;
-			}
-			else
-			{
-				// Too many retries - abandon ship.
-				console.log(invocationData.methodName + " failed with TooManyRequestsException and reached max retry count (" + _maxRetries + ")");
-			}
-		}
+                // Drop out so we don't invoke the original callback.
+                return;
+            }
 
-		// If we reach here, the call either:
-		//  - succeeded (yay);
-		//  - failed with an error other than TooManyRequests;
-		//  - reached the max retry count after numerous TooManyRequests errors.
-		// Whichever, we still need to invoke the original callback.
-		invocationData.originalCallback(err, data);
-	};
+            // Too many retries - abandon ship.
+            logger.log(invocationData.methodName + ' failed with TooManyRequestsException and reached max retry count (' + _maxRetries + ')');
+        }
 
-	method.call(invocationData.apiGateway, invocationData.params, retryCheck);
+        // If we reach here, the call either:
+        //  - succeeded (yay);
+        //  - failed with an error other than TooManyRequests;
+        //  - reached the max retry count after numerous TooManyRequests errors.
+        // Whichever, we still need to invoke the original callback.
+        invocationData.originalCallback(err, data);
+    };
+
+    invocationData.method.call(invocationData.apiGateway, invocationData.params, retryCheck);
 }
 
-function _isRetryableError (err) {
-	return err && (err.code === "TooManyRequestsException");
+function _isRetryableError(err) {
+    return err
+        && err.code === 'TooManyRequestsException';
 }
+
+function _getRetryInterval() {
+    var retryWindow = 5000;
+    return _minRetryIntervalMs
+        + Math.random() * retryWindow;
+}
+
+module.exports = GetWrappedService;

--- a/lib/service/util/api-gateway-retry-wrapper.js
+++ b/lib/service/util/api-gateway-retry-wrapper.js
@@ -5,7 +5,7 @@ var aws = require('aws-sdk');
 var _minRetryIntervalMs;
 var _maxRetries;
 
-function GetWrappedService(options, minRetryIntervalMs, maxRetries) {
+function getWrappedService(options, minRetryIntervalMs, maxRetries) {
     _minRetryIntervalMs = minRetryIntervalMs || 2000;
     _maxRetries = maxRetries || 8;
 

--- a/lib/service/util/api-gateway-retry-wrapper.js
+++ b/lib/service/util/api-gateway-retry-wrapper.js
@@ -94,7 +94,7 @@ function _invokeInnerMethod(invocationData) {
             if (++invocationData.retryCount < _maxRetries) {
                 // Wait then retry.
                 var retryIntervalMs = _getRetryInterval();
-                logger.log(invocationData.methodName + ' failed with TooManyRequestsException; retrying in ' + retryIntervalMs); setTimeout(function () {
+                logger.log(invocationData.methodName + ' failed with a retryable error; retrying in ' + retryIntervalMs); setTimeout(function () {
                     logger.log('Retrying ' + invocationData.methodName);
                     _invokeInnerMethod(invocationData);
                 }, retryIntervalMs);
@@ -104,7 +104,7 @@ function _invokeInnerMethod(invocationData) {
             }
 
             // Too many retries - abandon ship.
-            logger.log(invocationData.methodName + ' failed with TooManyRequestsException and reached max retry count (' + _maxRetries + ')');
+            logger.log(invocationData.methodName + ' failed with a retryable error and reached max retry count (' + _maxRetries + ')');
         }
 
         // If we reach here, the call either:

--- a/lib/service/util/api-gateway-retry-wrapper.js
+++ b/lib/service/util/api-gateway-retry-wrapper.js
@@ -95,4 +95,4 @@ function _getRetryInterval() {
         + Math.random() * retryWindow;
 }
 
-module.exports = GetWrappedService;
+module.exports = getWrappedService;

--- a/lib/service/util/api-gateway-retry-wrapper.js
+++ b/lib/service/util/api-gateway-retry-wrapper.js
@@ -120,7 +120,8 @@ function _invokeInnerMethod(invocationData) {
 
 function _isRetryableError(err) {
     return err
-        && err.code === 'TooManyRequestsException';
+        && err.code === 'TooManyRequestsException'
+        || err.toString().indexOf("try again") > -1;
 }
 
 function _getRetryInterval() {

--- a/lib/service/util/api-gateway-retry-wrapper.js
+++ b/lib/service/util/api-gateway-retry-wrapper.js
@@ -16,21 +16,47 @@ function getWrappedService(options, minRetryIntervalMs, maxRetries) {
 }
 
 function _wrapMethods(apiGateway) {
-    for (var prop in apiGateway) {
-        if (!apiGateway.hasOwnProperty(prop)) {
-            continue;
-        }
+    var methodsToWrap = [
+        "getBasePathMapping",
+        "createBasePathMapping",
+        "deleteBasePathMapping",
+        "updateBasePathMapping",
+        "getDomainName",
+        "createDomainName",
+        "deleteDomainName",
+        "updateDomainName",
+        "getMethod",
+        "deleteMethod",
+        "putMethod",
+        "putIntegration",
+        "putMethodResponse",
+        "updateMethodResponse",
+        "putIntegrationResponse",
+        "updateIntegrationResponse",
+        "getModel",
+        "createModel",
+        "deleteModel",
+        "updateModel",
+        "getResource",
+        "createResource",
+        "deleteResource",
+        "updateResource",
+        "getResources",
+        "getRestApi",
+        "createRestApi",
+        "deleteRestApi",
+        "updateRestApi",
+        "getRestApis"
+    ];
 
-        var value = apiGateway[prop];
+    for (var i = 0; i < methodsToWrap.length; i++)
+    {
+        var methodName = methodsToWrap[i];
+        var method = apiGateway[methodName];
 
-        if (_isWrappableMethod(value)) {
-            _wrapMethod(apiGateway, prop, value);
-        }
+        logger.log("Wrapping method " + methodName);
+        _wrapMethod(apiGateway, methodName, method);
     }
-}
-
-function _isWrappableMethod(value) {
-    return typeof value === 'function';
 }
 
 function _wrapMethod(apiGateway, methodName, method) {
@@ -38,7 +64,9 @@ function _wrapMethod(apiGateway, methodName, method) {
 }
 
 function _getWrappedMethod(apiGateway, methodName, method) {
+    logger.log("Getting wrapper for " + methodName);
     return function (params, callback) {
+        logger.log("Calling wrappedMethod: " + methodName);
         var invocationData = {
             apiGateway: apiGateway,
             methodName: methodName,
@@ -54,8 +82,14 @@ function _getWrappedMethod(apiGateway, methodName, method) {
 }
 
 function _invokeInnerMethod(invocationData) {
+    logger.log("_invokeInnerMethod: invocationData =");
+    logger.log(invocationData);
+
     // Replace the original callback with our own to check for TooManyRequests exceptions.
     var retryCheck = function (err, data) { //eslint-disable-line func-style
+        logger.log(invocationData.methodName + " completed.\n"
+                                             + "retryCheck(err: " + err + ", data: " + data + ")");
+
         if (err && _isRetryableError(err)) {
             if (++invocationData.retryCount < _maxRetries) {
                 // Wait then retry.

--- a/lib/service/util/api-gateway-retry-wrapper.js
+++ b/lib/service/util/api-gateway-retry-wrapper.js
@@ -17,44 +17,43 @@ function getWrappedService(options, minRetryIntervalMs, maxRetries) {
 
 function _wrapMethods(apiGateway) {
     var methodsToWrap = [
-        "getBasePathMapping",
-        "createBasePathMapping",
-        "deleteBasePathMapping",
-        "updateBasePathMapping",
-        "getDomainName",
-        "createDomainName",
-        "deleteDomainName",
-        "updateDomainName",
-        "getMethod",
-        "deleteMethod",
-        "putMethod",
-        "putIntegration",
-        "putMethodResponse",
-        "updateMethodResponse",
-        "putIntegrationResponse",
-        "updateIntegrationResponse",
-        "getModel",
-        "createModel",
-        "deleteModel",
-        "updateModel",
-        "getResource",
-        "createResource",
-        "deleteResource",
-        "updateResource",
-        "getResources",
-        "getRestApi",
-        "createRestApi",
-        "deleteRestApi",
-        "updateRestApi",
-        "getRestApis"
+        'getBasePathMapping',
+        'createBasePathMapping',
+        'deleteBasePathMapping',
+        'updateBasePathMapping',
+        'getDomainName',
+        'createDomainName',
+        'deleteDomainName',
+        'updateDomainName',
+        'getMethod',
+        'deleteMethod',
+        'putMethod',
+        'putIntegration',
+        'putMethodResponse',
+        'updateMethodResponse',
+        'putIntegrationResponse',
+        'updateIntegrationResponse',
+        'getModel',
+        'createModel',
+        'deleteModel',
+        'updateModel',
+        'getResource',
+        'createResource',
+        'deleteResource',
+        'updateResource',
+        'getResources',
+        'getRestApi',
+        'createRestApi',
+        'deleteRestApi',
+        'updateRestApi',
+        'getRestApis'
     ];
 
-    for (var i = 0; i < methodsToWrap.length; i++)
-    {
+    for (var i = 0; i < methodsToWrap.length; i++) {
         var methodName = methodsToWrap[i];
         var method = apiGateway[methodName];
 
-        logger.log("Wrapping method " + methodName);
+        logger.log('Wrapping method ' + methodName);
         _wrapMethod(apiGateway, methodName, method);
     }
 }
@@ -64,9 +63,9 @@ function _wrapMethod(apiGateway, methodName, method) {
 }
 
 function _getWrappedMethod(apiGateway, methodName, method) {
-    logger.log("Getting wrapper for " + methodName);
+    logger.log('Getting wrapper for ' + methodName);
     return function (params, callback) {
-        logger.log("Calling wrappedMethod: " + methodName);
+        logger.log('Calling wrappedMethod: ' + methodName);
         var invocationData = {
             apiGateway: apiGateway,
             methodName: methodName,
@@ -82,13 +81,13 @@ function _getWrappedMethod(apiGateway, methodName, method) {
 }
 
 function _invokeInnerMethod(invocationData) {
-    logger.log("_invokeInnerMethod: invocationData =");
+    logger.log('_invokeInnerMethod: invocationData =');
     logger.log(invocationData);
 
     // Replace the original callback with our own to check for TooManyRequests exceptions.
     var retryCheck = function (err, data) { //eslint-disable-line func-style
-        logger.log(invocationData.methodName + " completed.\n"
-                                             + "retryCheck(err: " + err + ", data: " + data + ")");
+        logger.log(invocationData.methodName + ' completed.\n'
+                                             + 'retryCheck(err: ' + err + ', data: ' + data + ')');
 
         if (err && _isRetryableError(err)) {
             if (++invocationData.retryCount < _maxRetries) {
@@ -121,7 +120,7 @@ function _invokeInnerMethod(invocationData) {
 function _isRetryableError(err) {
     return err
         && err.code === 'TooManyRequestsException'
-        || err.toString().indexOf("try again") > -1;
+        || err.toString().indexOf('try again') > -1;
 }
 
 function _getRetryInterval() {


### PR DESCRIPTION
'TooManyRequestsException' sometimes seen when calling the APIGateway to deploy a complicated stack. Added an api-gateway-retry-wrapper utility that is used in place of the APIGateway to retry requests that fail with this exception.

Defaults:
 max retries: 8,
 min retry interval (milliseconds): 2000,
 retry window (milliseconds): 5000
(so it retries up to 8 times at a random point between 2 and 7 seconds after each failure).