### PR TITLE
Fix the custom ApiDeploy commend docs

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2032,7 +2032,7 @@
                         <div class="panel-heading">
                             <h3 class="panel-title">
                                 <span class="glyphicon glyphicon-chevron-down" data-collapse title="click to collapse/expand"></span>
-                                Custom::DeployApi
+                                Custom::ApiDeploy
                                 <span class="label label-info pull-right">Since v1.5.0</span>
                             </h3>
                         </div>
@@ -2240,7 +2240,7 @@
                             <h3>CloudFormation Template Example</h3>
                             <pre>
                                 "DeployApi": {
-                                    "Type": "Custom::DeployApi",
+                                    "Type": "Custom::ApiDeploy",
                                     "Properties": {
                                         "ServiceToken": {Lambda_Function_ARN},
                                         "restApiId": "xyz123",


### PR DESCRIPTION
The docs showed using `DeployApi`, but the command is actually `ApiDeploy`.