### PR TITLE
Update certificate parsing for certificate chains with multiple certificates

### DIFF
--- a/lib/service/util/certificate-parser.js
+++ b/lib/service/util/certificate-parser.js
@@ -18,14 +18,20 @@ pub.parseCertificate = function (certificate, part) {
         throw new Error('Invalid certificate part specified', { givenPart: part, allowedParts: pub.CERTIFICATE_PART });
     }
     var cleanString = certificate
-        .replace(certHeaderFooter[part].header, '')// Remove header and footer, we'll re-add them later
-        .replace(certHeaderFooter[part].footer, '')
-        .trim() // Trim to be sure we don't inject a bad new line
+        .replace(new RegExp(certHeaderFooter[part].header, 'g'), 'CERTHEADERFOOTERHEADER') // Remove headers and footers, we'll re-add them later
+        .replace(new RegExp(certHeaderFooter[part].footer, 'g'), 'CERTHEADERFOOTERFOOTER')
+
         .replace(/\\n/g, '\n') // Replace escaped new line with proper new line
         .replace(/ /g, '\n') // Replace space with new line
-        .trim(); // Add a final trim as a new line might have slipped in at the end
-    // Rebuild cert with header and footer
-    return certHeaderFooter[part].header + '\n' + cleanString + '\n' + certHeaderFooter[part].footer;
+
+
+        .replace(/CERTHEADERFOOTERHEADER\n/g, 'CERTHEADERFOOTERHEADER') // Remove any extra newlines that have snuck in
+        .replace(/\nCERTHEADERFOOTERFOOTER/g, 'CERTHEADERFOOTERFOOTER')
+
+        .replace(/CERTHEADERFOOTERHEADER/g, certHeaderFooter[part].header + '\n') // Replace headers and footers
+        .replace(/CERTHEADERFOOTERFOOTER/g, '\n' + certHeaderFooter[part].footer);
+
+    return cleanString;
 };
 
 module.exports = pub;

--- a/tests/unit/service/util/certificate-parser-unit-test.js
+++ b/tests/unit/service/util/certificate-parser-unit-test.js
@@ -8,23 +8,46 @@ describe('certificateParser', function () {
 
     describe('ParseCertificate', function () {
         describe('Parse CHAIN part', function () {
-            it('should give a valid certificate with newline', function (done) {
-                var certificate = '-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----';
-                var parsedCertificate = testSubject.parseCertificate(certificate, testSubject.CERTIFICATE_PART.CHAIN);
-                expect(parsedCertificate).to.equal('-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----');
-                done();
+            describe('with one certificate', function () {
+                it('should give a valid certificate with newline', function (done) {
+                    var certificate = '-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----';
+                    var parsedCertificate = testSubject.parseCertificate(certificate, testSubject.CERTIFICATE_PART.CHAIN);
+                    expect(parsedCertificate).to.equal('-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----');
+                    done();
+                });
+                it('should give a valid certificate with space', function (done) {
+                    var certificate = '-----BEGIN CERTIFICATE----- line1 line2 -----END CERTIFICATE-----';
+                    var parsedCertificate = testSubject.parseCertificate(certificate, testSubject.CERTIFICATE_PART.CHAIN);
+                    expect(parsedCertificate).to.equal('-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----');
+                    done();
+                });
+                it('should give a valid certificate with escaped newline', function (done) {
+                    var certificate = '-----BEGIN CERTIFICATE-----\\nline1\\nline2\\n-----END CERTIFICATE-----';
+                    var parsedCertificate = testSubject.parseCertificate(certificate, testSubject.CERTIFICATE_PART.CHAIN);
+                    expect(parsedCertificate).to.equal('-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----');
+                    done();
+                });
             });
-            it('should give a valid certificate with space', function (done) {
-                var certificate = '-----BEGIN CERTIFICATE----- line1 line2 -----END CERTIFICATE-----';
-                var parsedCertificate = testSubject.parseCertificate(certificate, testSubject.CERTIFICATE_PART.CHAIN);
-                expect(parsedCertificate).to.equal('-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----');
-                done();
-            });
-            it('should give a valid certificate with escaped newline', function (done) {
-                var certificate = '-----BEGIN CERTIFICATE-----\\nline1\\nline2\\n-----END CERTIFICATE-----';
-                var parsedCertificate = testSubject.parseCertificate(certificate, testSubject.CERTIFICATE_PART.CHAIN);
-                expect(parsedCertificate).to.equal('-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----');
-                done();
+            describe('with multiple certificates', function () {
+
+                it('should give a valid certificate with newline', function (done) {
+                    var certificate = '-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nline3\nline4\n-----END CERTIFICATE-----';
+                    var parsedCertificate = testSubject.parseCertificate(certificate, testSubject.CERTIFICATE_PART.CHAIN);
+                    expect(parsedCertificate).to.equal('-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nline3\nline4\n-----END CERTIFICATE-----');
+                    done();
+                });
+                it('should give a valid certificate with space', function (done) {
+                    var certificate = '-----BEGIN CERTIFICATE----- line1 line2 -----END CERTIFICATE----- -----BEGIN CERTIFICATE----- line3 line4 -----END CERTIFICATE-----';
+                    var parsedCertificate = testSubject.parseCertificate(certificate, testSubject.CERTIFICATE_PART.CHAIN);
+                    expect(parsedCertificate).to.equal('-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nline3\nline4\n-----END CERTIFICATE-----');
+                    done();
+                });
+                it('should give a valid certificate with escaped newline', function (done) {
+                    var certificate = '-----BEGIN CERTIFICATE-----\\nline1\\nline2\\n-----END CERTIFICATE-----\\n-----BEGIN CERTIFICATE-----\\nline3\\nline4\\n-----END CERTIFICATE-----';
+                    var parsedCertificate = testSubject.parseCertificate(certificate, testSubject.CERTIFICATE_PART.CHAIN);
+                    expect(parsedCertificate).to.equal('-----BEGIN CERTIFICATE-----\nline1\nline2\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nline3\nline4\n-----END CERTIFICATE-----');
+                    done();
+                });
             });
         });
         describe('Parse BODY part', function () {


### PR DESCRIPTION
Fix for https://github.com/carlnordenfelt/aws-api-gateway-for-cloudformation/issues/49.

Update the certificate parsing so that it works when certificate chains have multiple certificates within them.

@carlnordenfelt Can you review & merge please?